### PR TITLE
Fix broken tests - SUMR rewards removed for some vaults

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+	"editor.formatOnSave": true,
+	"editor.formatOnPaste": true,
+	"editor.defaultFormatter": "esbenp.prettier-vscode",
+	"[typescript]": {
+		"editor.formatOnSave": true
+	},
+	"editor.codeActionsOnSave": {
+		"source.fixAll.eslint": "explicit",
+		"source.organizeImports": "explicit"
+	}
+}

--- a/srcEarnProtocol/tooltips/netApy.ts
+++ b/srcEarnProtocol/tooltips/netApy.ts
@@ -80,7 +80,7 @@ export class NetApy {
 	}
 
 	@step
-	async getDetails(args?: { withWstethRewards: boolean }) {
+	async getDetails(args?: { withoutSumrRewards?: boolean; withWstethRewards?: boolean }) {
 		const details = {
 			liveNativeApy: '',
 			sumrRewards: '',
@@ -95,8 +95,10 @@ export class NetApy {
 			liveNativeApy.indexOf('%'),
 		);
 
-		const sumrRewards: string = await this.sumrRewardsLocator.innerText();
-		details.sumrRewards = sumrRewards.replace('%', '');
+		if (!args?.withoutSumrRewards) {
+			const sumrRewards: string = await this.sumrRewardsLocator.innerText();
+			details.sumrRewards = sumrRewards.replace('%', '');
+		}
 
 		if (args?.withWstethRewards) {
 			const wstethRewards: string = await this.wstethRewardsLocator.innerText();

--- a/testsEarnProtocol/noWallet/vaultPages/arbitrumUSDC.spec.ts
+++ b/testsEarnProtocol/noWallet/vaultPages/arbitrumUSDC.spec.ts
@@ -17,13 +17,12 @@ test.describe('Vault page - Arbitrum USDC', async () => {
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -32,10 +31,8 @@ test.describe('Vault page - Arbitrum USDC', async () => {
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 

--- a/testsEarnProtocol/noWallet/vaultPages/arbitrumUSDT.spec.ts
+++ b/testsEarnProtocol/noWallet/vaultPages/arbitrumUSDT.spec.ts
@@ -18,13 +18,12 @@ test.describe('Vault page - Arbitrum USDT', async () => {
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -33,10 +32,8 @@ test.describe('Vault page - Arbitrum USDT', async () => {
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 

--- a/testsEarnProtocol/noWallet/vaultPages/hyperliquidUSDC.spec.ts
+++ b/testsEarnProtocol/noWallet/vaultPages/hyperliquidUSDC.spec.ts
@@ -23,13 +23,12 @@ test.describe('Vault page - Hyperliquid USDC', async () => {
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -38,10 +37,8 @@ test.describe('Vault page - Hyperliquid USDC', async () => {
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 

--- a/testsEarnProtocol/noWallet/vaultPages/hyperliquidUSDT.spec.ts
+++ b/testsEarnProtocol/noWallet/vaultPages/hyperliquidUSDT.spec.ts
@@ -23,13 +23,12 @@ test.describe('Vault page - Hyperliquid USD₮0', async () => {
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -38,10 +37,8 @@ test.describe('Vault page - Hyperliquid USD₮0', async () => {
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 

--- a/testsEarnProtocol/noWallet/vaultPages/sonicUSDCE.spec.ts
+++ b/testsEarnProtocol/noWallet/vaultPages/sonicUSDCE.spec.ts
@@ -21,13 +21,12 @@ test.describe('Vault page - Sonic USDC.E', async () => {
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -36,10 +35,8 @@ test.describe('Vault page - Sonic USDC.E', async () => {
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 

--- a/testsEarnProtocol/withRealWallet/arbitrum/usdcPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/arbitrum/usdcPositionPage.spec.ts
@@ -1,11 +1,11 @@
-import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletArbitrumFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletArbitrum';
-import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout, extremelyLongTestTimeout } from 'utils/config';
-import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
-import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
-import { switchPosition } from 'testsEarnProtocol/z_sharedTestSteps/switch';
 import { expect } from '#earnProtocolFixtures';
+import { testWithSynpress } from '@synthetixio/synpress';
+import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
+import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
+import { switchPosition } from 'testsEarnProtocol/z_sharedTestSteps/switch';
+import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
+import { expectDefaultTimeout, extremelyLongTestTimeout } from 'utils/config';
+import { test as withRealWalletArbitrumFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletArbitrum';
 
 const test = testWithSynpress(withRealWalletArbitrumFixtures);
 
@@ -36,13 +36,12 @@ test.describe('With real wallet - Arbitrum USDC Position page - APY tag @arbitru
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -51,10 +50,8 @@ test.describe('With real wallet - Arbitrum USDC Position page - APY tag @arbitru
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 });

--- a/testsEarnProtocol/withRealWallet/arbitrum/usdtPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/arbitrum/usdtPositionPage.spec.ts
@@ -1,12 +1,12 @@
+import { expect } from '#earnProtocolFixtures';
 import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletArbitrumFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletArbitrum';
 import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout, extremelyLongTestTimeout } from 'utils/config';
 import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
-import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
 import { switchPosition } from 'testsEarnProtocol/z_sharedTestSteps/switch';
 import { unstakeLvTokens } from 'testsEarnProtocol/z_sharedTestSteps/unstakeLvTokens';
-import { expect } from '#earnProtocolFixtures';
+import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
+import { expectDefaultTimeout, extremelyLongTestTimeout } from 'utils/config';
+import { test as withRealWalletArbitrumFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletArbitrum';
 
 const test = testWithSynpress(withRealWalletArbitrumFixtures);
 
@@ -37,13 +37,12 @@ test.describe('With real wallet - Arbitrum USD₮0 Position page - APY tag @arbi
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -52,10 +51,8 @@ test.describe('With real wallet - Arbitrum USD₮0 Position page - APY tag @arbi
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 });

--- a/testsEarnProtocol/withRealWallet/hyperliquid/usdcPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/hyperliquid/usdcPositionPage.spec.ts
@@ -1,10 +1,10 @@
+import { expect } from '#earnProtocolFixtures';
 import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletHyperliquidFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletHyperliquid';
 import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
 import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
 import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
-import { expect } from '#earnProtocolFixtures';
+import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
+import { test as withRealWalletHyperliquidFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletHyperliquid';
 
 const test = testWithSynpress(withRealWalletHyperliquidFixtures);
 
@@ -35,25 +35,22 @@ test.describe('With real wallet - Hyperliquid USDC Position page - APY tag', asy
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
 			`Card Net APY(${tagNetApy}) should equal Card Tooltip Net APY (${tooltipDetails.netApy})`,
 		).toEqual(tooltipDetails.netApy);
 
-		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
+		// Verify that tooltip Net APY equals tooltip Native Live APY - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 });

--- a/testsEarnProtocol/withRealWallet/hyperliquid/usdtPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/hyperliquid/usdtPositionPage.spec.ts
@@ -1,10 +1,10 @@
+import { expect } from '#earnProtocolFixtures';
 import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletHyperliquidFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletHyperliquid';
 import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
 import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
 import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
-import { expect } from '#earnProtocolFixtures';
+import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
+import { test as withRealWalletHyperliquidFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletHyperliquid';
 
 const test = testWithSynpress(withRealWalletHyperliquidFixtures);
 
@@ -35,13 +35,12 @@ test.describe('With real wallet - Hyperliquid USD₮0 Position page - APY tag', 
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -50,10 +49,8 @@ test.describe('With real wallet - Hyperliquid USD₮0 Position page - APY tag', 
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 });

--- a/testsEarnProtocol/withRealWallet/sonic/usdcePositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/sonic/usdcePositionPage.spec.ts
@@ -1,11 +1,11 @@
-import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletSonicFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletSonic';
-import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
-import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
-import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
-import { unstakeLvTokens } from 'testsEarnProtocol/z_sharedTestSteps/unstakeLvTokens';
 import { expect } from '#earnProtocolFixtures';
+import { testWithSynpress } from '@synthetixio/synpress';
+import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
+import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
+import { unstakeLvTokens } from 'testsEarnProtocol/z_sharedTestSteps/unstakeLvTokens';
+import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
+import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
+import { test as withRealWalletSonicFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletSonic';
 
 const test = testWithSynpress(withRealWalletSonicFixtures);
 
@@ -36,13 +36,12 @@ test.describe('With real wallet - Sonic USDC.E Position page - APY tag', async (
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -51,10 +50,8 @@ test.describe('With real wallet - Sonic USDC.E Position page - APY tag', async (
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 });


### PR DESCRIPTION
**Detailed Changes**

**1. VS Code Settings (.vscode/settings.json)**
- Added auto-formatting and auto-linting on save: Configured Prettier as the default formatter and enabled editor.formatOnSave along with ESLint source.fixAll.eslint and source.organizeImports on save.

**2. Net APY Tooltip Helper (srcEarnProtocol/tooltips/netApy.ts)**
- Enhanced getDetails Method: Introduced an optional args configuration object supporting { withoutSumrRewards?: boolean; withWstethRewards?: boolean }.
- Conditional Parsing: Correctly skips awaiting and extracting text from sumrRewardsLocator when withoutSumrRewards is set to true, preventing timeouts when expecting a tooltip without SUMR rewards.

**3. E2E Tests (noWallet & withRealWallet)**
Updated the following vault/position pages (Arbitrum USDC/USDT, Hyperliquid USDC/USDT, and Sonic USDC.E):
- Tooltip Expectations: Removed the sumrRewards regex field from app.tooltips.netApy.shouldHave(...).
- Details Fetching: Updated calls to use the new argument: await app.tooltips.netApy.getDetails({ withoutSumrRewards: true }).
- Calculation Assertions: Updated the expected mathematical formula and description strings to verify that Net APY ≈ Native APY - Management Fee (removing the SUMR rewards component).
- Organized Imports: Benefited cleanly from the newly introduced automated import sorting/formatting.