### PR TITLE
Fix broken test - SUMR rewards removed from Mainnet USDT vaults

### DIFF
--- a/srcEarnProtocol/pages/portfolio/index.ts
+++ b/srcEarnProtocol/pages/portfolio/index.ts
@@ -1,5 +1,6 @@
 import { expect, step, test } from '#earnProtocolFixtures';
 import { Locator, Page } from '@playwright/test';
+import { LazyNominatedTokens, Networks, RiskLevels } from 'srcEarnProtocol/utils/types';
 import { expectDefaultTimeout } from 'utils/config';
 import { BeachClub } from './beachClub';
 import { Bridge } from './bridge';
@@ -7,10 +8,9 @@ import { Overview } from './overview';
 import { RebalanceActivity } from './rebalanceActivity';
 import { Rewards } from './rewards';
 import { Send } from './send';
+import { Wallet } from './wallet';
 import { YouMightLike } from './youMightLike';
 import { YourActivity } from './yourActivity';
-import { Wallet } from './wallet';
-import { LazyNominatedTokens, Networks, RiskLevels } from 'srcEarnProtocol/utils/types';
 
 type Tabs =
 	| 'Overview'
@@ -98,34 +98,14 @@ export class Portfolio {
 	}
 
 	@step
-	async shouldShowOverviewAmounts({
-		total$SUMR,
-		totalWallet,
-		timeout,
-	}: {
-		total$SUMR: string;
-		totalWallet: string;
-		timeout?: number;
-	}) {
-		if (total$SUMR) {
-			const regExp = new RegExp(total$SUMR);
-			await expect(
-				this.portfolioSecondHeaderLocator
-					.locator('[class*="_dataBlockWrapper_"]')
-					.filter({ has: this.page.getByText('Total $SUMR', { exact: true }) })
-					.locator('span'),
-			).toContainText(regExp, { timeout: timeout ?? expectDefaultTimeout });
-		}
-
-		if (totalWallet) {
-			const regExp = new RegExp(`\\$${totalWallet}`);
-			await expect(
-				this.portfolioSecondHeaderLocator
-					.locator('[class*="_dataBlockWrapper_"]')
-					.filter({ has: this.page.getByText('Total Wallet Value', { exact: true }) })
-					.locator('span'),
-			).toContainText(regExp, { timeout: timeout ?? expectDefaultTimeout });
-		}
+	async shouldShowtotal$SUMR({ total$SUMR, timeout }: { total$SUMR: string; timeout?: number }) {
+		const regExp = new RegExp(total$SUMR);
+		await expect(
+			this.portfolioSecondHeaderLocator
+				.locator('[class*="_dataBlockWrapper_"]')
+				.filter({ has: this.page.getByText('Total $SUMR', { exact: true }) })
+				.locator('span'),
+		).toContainText(regExp, { timeout: timeout ?? expectDefaultTimeout });
 	}
 
 	@step

--- a/testsEarnProtocol/noWallet/vaultPages/mainnetUSDT.spec.ts
+++ b/testsEarnProtocol/noWallet/vaultPages/mainnetUSDT.spec.ts
@@ -18,13 +18,12 @@ test.describe('Vault page - Mainnet USDT', async () => {
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -33,10 +32,8 @@ test.describe('Vault page - Mainnet USDT', async () => {
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 

--- a/testsEarnProtocol/withRealWallet/mainnet/usdtPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/mainnet/usdtPositionPage.spec.ts
@@ -1,12 +1,12 @@
+import { expect } from '#earnProtocolFixtures';
 import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletBaseFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletBase';
 import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
 import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
-import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
 import { switchPosition } from 'testsEarnProtocol/z_sharedTestSteps/switch';
 import { unstakeLvTokens } from 'testsEarnProtocol/z_sharedTestSteps/unstakeLvTokens';
-import { expect } from '#earnProtocolFixtures';
+import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
+import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
+import { test as withRealWalletBaseFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletBase';
 
 const test = testWithSynpress(withRealWalletBaseFixtures);
 
@@ -41,13 +41,12 @@ test.describe('With real wallet - Mainnet USDT Position page - APY tag', async (
 
 		await app.tooltips.netApy.shouldHave({
 			liveNativeApy: '[0-9]{1,2}.[0-9]{2}',
-			sumrRewards: '[0-9]{1,2}.[0-9]{2}',
 			managementFee: '1.00',
 			netApy: '[0-9]{1,2}.[0-9]{2}',
 		});
 
 		// Get Net APY in tag tooltip
-		const tooltipDetails = await app.tooltips.netApy.getDetails();
+		const tooltipDetails = await app.tooltips.netApy.getDetails({ withoutSumrRewards: true });
 		// Verify that tag and tooltip Net APY match
 		expect(
 			tagNetApy,
@@ -56,10 +55,8 @@ test.describe('With real wallet - Mainnet USDT Position page - APY tag', async (
 
 		// Verify that tooltip Net APY equals tooltip Native Live APY + SUMR rewards - Management Fee
 		expect(
-			parseFloat(tooltipDetails.liveNativeApy) +
-				parseFloat(tooltipDetails.sumrRewards) -
-				parseFloat(tooltipDetails.managementFee),
-			`Native APY (${tooltipDetails.liveNativeApy}) + SUMR (${tooltipDetails.sumrRewards}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
+			parseFloat(tooltipDetails.liveNativeApy) - parseFloat(tooltipDetails.managementFee),
+			`Native APY (${tooltipDetails.liveNativeApy}) - Fee (${tooltipDetails.managementFee}) should be very close to Net APY (${tooltipDetails.netApy})`,
 		).toBeCloseTo(parseFloat(tooltipDetails.netApy), 1);
 	});
 });


### PR DESCRIPTION
## Description

This PR updates the Mainnet USDT vault test suites to align with the removal of `$SUMR` rewards and refactors overview amount checks in the Portfolio page object.

### Changes

- **Mainnet USDT Vault Tests (`noWallet` & `withRealWallet`)**:
  - Updated APY tooltip assertions to reflect the removal of `$SUMR` rewards.
  - Removed `sumrRewards` expectation from the tooltip content verification.
  - Configured `getDetails({ withoutSumrRewards: true })` to correctly parse tooltip values without expecting SUMR rewards.
  - Adjusted the Net APY calculation assertion to verify `Net APY ≈ Native Live APY - Management Fee`.

- **Portfolio Page Object (`srcEarnProtocol/pages/portfolio/index.ts`)**:
  - Replaced `shouldShowOverviewAmounts` with a focused `shouldShowtotal$SUMR` step method, removing the unused wallet total value verification.
  - Automated import sorting and formatting cleanups.
