### PR TITLE
Update tests related to claiming rewards

### DIFF
--- a/srcEarnProtocol/pages/portfolio/rewards/claimAndDelegate.ts
+++ b/srcEarnProtocol/pages/portfolio/rewards/claimAndDelegate.ts
@@ -14,14 +14,14 @@ export class ClaimAndDelegate {
 	async shouldBeVisible(args?: { timeout?: number }) {
 		await expect(
 			this.page.getByText('Claim').first(),
-			'"Claim" header in Claim page should be visible'
+			'"Claim" header in Claim page should be visible',
 		).toBeVisible({ timeout: args?.timeout ?? expectDefaultTimeout });
 	}
 
 	@step
 	async shouldHaveButton(
 		button: 'Reject' | 'Accept & Sign' | 'Loading' | 'Continue',
-		args?: { hidden: boolean }
+		args?: { hidden: boolean },
 	) {
 		if (args?.hidden) {
 			await expect(this.page.locator(`button:has-text("${button}")`)).not.toBeVisible();
@@ -51,7 +51,7 @@ export class ClaimAndDelegate {
 			networkName: 'Arbitrum' | 'Base' | 'Ethereum' | 'Sonic';
 			claimable: string;
 			inWallet: string;
-		}[]
+		}[],
 	) {
 		for (const network of networks) {
 			const claimableRegExp = new RegExp(network.claimable);
@@ -82,10 +82,15 @@ export class ClaimAndDelegate {
 		const haveEarnedLocator = this.page.locator('p:has-text("You have claimed")');
 
 		await expect(haveEarnedLocator.locator('xpath=//following-sibling::div[1]')).toContainText(
-			sumrRegExp
+			sumrRegExp,
 		);
 		await expect(haveEarnedLocator.locator('xpath=//following-sibling::p[1]')).toContainText(
-			usdRegExp
+			usdRegExp,
 		);
+	}
+
+	@step
+	async approveStakingRewardsCaller() {
+		await this.page.getByRole('button', { name: 'Approve Staking Rewards Caller' }).click();
 	}
 }

--- a/srcEarnProtocol/pages/portfolio/rewards/index.ts
+++ b/srcEarnProtocol/pages/portfolio/rewards/index.ts
@@ -1,7 +1,7 @@
-import { Locator, Page } from '@playwright/test';
-import { ClaimAndDelegate } from './claimAndDelegate';
 import { expect, step } from '#earnProtocolFixtures';
+import { Locator, Page } from '@playwright/test';
 import { expectDefaultTimeout } from 'utils/config';
+import { ClaimAndDelegate } from './claimAndDelegate';
 
 export class Rewards {
 	readonly page: Page;
@@ -22,12 +22,12 @@ export class Rewards {
 	async shouldBeVisible() {
 		await expect(
 			this.page.getByText('Your Total $SUMR'),
-			'"Your Total $SUMR" should be visible'
+			'"Your Total $SUMR" should be visible',
 		).toBeVisible({ timeout: expectDefaultTimeout * 2 });
 
 		await expect(
 			this.page.getByText('Total $SUMR available to claim', { exact: true }),
-			'"$SUMR available to claim" should be visible'
+			'"$SUMR available to claim" should be visible',
 		).toBeVisible();
 	}
 
@@ -36,6 +36,26 @@ export class Rewards {
 		await this.page
 			.getByRole('button', {
 				name: 'Claim $SUMR',
+				exact: true,
+			})
+			.click();
+	}
+
+	@step
+	async switchToBaseToClaimRewards() {
+		await this.page
+			.getByRole('button', {
+				name: 'Switch to Base to claim rewards',
+				exact: true,
+			})
+			.click();
+	}
+
+	@step
+	async claimRewards() {
+		await this.page
+			.getByRole('button', {
+				name: 'Claim rewards',
 				exact: true,
 			})
 			.click();
@@ -69,7 +89,7 @@ export class Rewards {
 			await expect(
 				this.priceLocator
 					.locator('[class*="_sumrPriceDataBlock_"]')
-					.filter({ hasText: 'Market Cap' })
+					.filter({ hasText: 'Market Cap' }),
 			).toContainText(regExp);
 		}
 
@@ -78,7 +98,7 @@ export class Rewards {
 			await expect(
 				this.priceLocator
 					.locator('[class*="_sumrPriceDataBlock_"]')
-					.filter({ hasText: 'Fully Diluted Valuation' })
+					.filter({ hasText: 'Fully Diluted Valuation' }),
 			).toContainText(regExp);
 		}
 
@@ -87,14 +107,16 @@ export class Rewards {
 			await expect(
 				this.priceLocator
 					.locator('[class*="_sumrPriceDataBlock_"]')
-					.filter({ hasText: 'SUMR Holders' })
+					.filter({ hasText: 'SUMR Holders' }),
 			).toContainText(regExp);
 		}
 
 		if (sevenDaysTrend) {
 			const regExp = new RegExp(`${sevenDaysTrend}%`);
 			await expect(
-				this.priceLocator.locator('[class*="_sumrPriceDataBlock_"]').filter({ hasText: '7d Trend' })
+				this.priceLocator
+					.locator('[class*="_sumrPriceDataBlock_"]')
+					.filter({ hasText: '7d Trend' }),
 			).toContainText(regExp);
 		}
 
@@ -103,7 +125,7 @@ export class Rewards {
 			await expect(
 				this.priceLocator
 					.locator('[class*="_sumrPriceDataBlock_"]')
-					.filter({ hasText: '30d Trend' })
+					.filter({ hasText: '30d Trend' }),
 			).toContainText(regExp);
 		}
 
@@ -112,7 +134,7 @@ export class Rewards {
 			await expect(
 				this.priceLocator
 					.locator('[class*="_sumrPriceDataBlock_"]')
-					.filter({ hasText: '90d Trend' })
+					.filter({ hasText: '90d Trend' }),
 			).toContainText(regExp);
 		}
 	}

--- a/testsEarnProtocol/production/realWallet/sumrRewards.spec.ts
+++ b/testsEarnProtocol/production/realWallet/sumrRewards.spec.ts
@@ -1,8 +1,8 @@
-import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletSonicFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletSonic';
-import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout } from 'utils/config';
 import { expect } from '#earnProtocolFixtures';
+import { testWithSynpress } from '@synthetixio/synpress';
+import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
+import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
+import { test as withRealWalletSonicFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletSonic';
 
 const test = testWithSynpress(withRealWalletSonicFixtures);
 
@@ -24,8 +24,9 @@ test.describe('Real wallet - Portfolio - SUMR rewards', async () => {
 		}).toPass();
 	});
 
-	// SKIP - PRIVY - test to be updated
-	test.skip('It should claim rewards (until tx) @regression', async ({ app, metamask }) => {
+	test('It should claim rewards (until tx) @regression', async ({ app, metamask }) => {
+		test.setTimeout(veryLongTestTimeout);
+
 		await expect(async () => {
 			await app.portfolio.rewards.claim();
 
@@ -60,12 +61,22 @@ test.describe('Real wallet - Portfolio - SUMR rewards', async () => {
 			},
 		]);
 
-		// Base rewards
-		await app.portfolio.rewards.claimAndDelegate.claim('Base');
+		// Sonic rewards --> This will fail until more SUMR are accrued on Sonic
+		await app.portfolio.rewards.claimAndDelegate.claim('Sonic');
 		await metamask.rejectTransaction();
 
 		// Pause to avoid random fails
-		await app.page.waitForTimeout(expectDefaultTimeout);
+		await app.page.waitForTimeout(3_000);
+
+		// Base rewards
+		await app.portfolio.rewards.claimAndDelegate.claim('Base');
+		await metamask.approveNewNetwork();
+		await metamask.approveSwitchNetwork();
+		await app.portfolio.rewards.claimAndDelegate.approveStakingRewardsCaller();
+		await metamask.rejectTransaction();
+
+		// Pause to avoid random fails
+		await app.page.waitForTimeout(3_000);
 
 		// Arbitrum rewards
 		await app.portfolio.rewards.claimAndDelegate.claim('Arbitrum');
@@ -77,18 +88,7 @@ test.describe('Real wallet - Portfolio - SUMR rewards', async () => {
 		}).toPass();
 
 		// Pause to avoid random fails
-		await app.page.waitForTimeout(expectDefaultTimeout);
-
-		// Sonic rewards --> This will fail until more SUMR are accrued on Sonic
-		await app.portfolio.rewards.claimAndDelegate.claim('Sonic');
-		await metamask.approveSwitchNetwork();
-		// Wait for Metamaskwindow to re-open
-		await expect(async () => {
-			await metamask.rejectTransaction();
-		}).toPass();
-
-		// Pause to avoid random fails
-		await app.page.waitForTimeout(expectDefaultTimeout);
+		await app.page.waitForTimeout(3_000);
 
 		// Mainnet rewards
 		await app.portfolio.rewards.claimAndDelegate.claim('Ethereum');

--- a/testsEarnProtocol/withRealWallet/portfolio/sumrRewards.spec.ts
+++ b/testsEarnProtocol/withRealWallet/portfolio/sumrRewards.spec.ts
@@ -1,8 +1,8 @@
+import { expect } from '#earnProtocolFixtures';
 import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletSonicFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletSonic';
 import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
 import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
-import { expect } from '#earnProtocolFixtures';
+import { test as withRealWalletSonicFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletSonic';
 
 const test = testWithSynpress(withRealWalletSonicFixtures);
 
@@ -37,8 +37,7 @@ test.describe('Real wallet - Portfolio - SUMR rewards', async () => {
 		await app.portfolio.rewards.shouldBeVisible();
 	});
 
-	// SKIP - Privy - Bug with privy - Wallet popup not triggered with 1st click when in different network
-	test.skip('It should claim rewards (until tx) @regression', async ({ app, metamask }) => {
+	test('It should claim rewards (until tx) @regression', async ({ app, metamask }) => {
 		test.setTimeout(veryLongTestTimeout);
 
 		await expect(async () => {
@@ -84,21 +83,10 @@ test.describe('Real wallet - Portfolio - SUMR rewards', async () => {
 
 		// Base rewards
 		await app.portfolio.rewards.claimAndDelegate.claim('Base');
-		//
-		await app.pause();
-		//
 		await metamask.approveNewNetwork();
-		//
-		await app.pause();
-		//
 		await metamask.approveSwitchNetwork();
-		//
-		await app.pause();
-		//
-		// Wait for Metamaskwindow to re-open
-		await expect(async () => {
-			await metamask.rejectTransaction();
-		}).toPass();
+		await app.portfolio.rewards.claimAndDelegate.approveStakingRewardsCaller();
+		await metamask.rejectTransaction();
 
 		// Pause to avoid random fails
 		await app.page.waitForTimeout(3_000);
@@ -115,9 +103,6 @@ test.describe('Real wallet - Portfolio - SUMR rewards', async () => {
 		// Pause to avoid random fails
 		await app.page.waitForTimeout(3_000);
 
-		// Pause to avoid random fails
-		await app.page.waitForTimeout(3_000);
-
 		// Mainnet rewards
 		await app.portfolio.rewards.claimAndDelegate.claim('Ethereum');
 		await metamask.approveSwitchNetwork();
@@ -128,8 +113,7 @@ test.describe('Real wallet - Portfolio - SUMR rewards', async () => {
 	});
 });
 
-// TO BE DONE in February once there are USDC rewards to be claimed
-test.describe.skip('Real wallet - Portfolio - Staking USDC rewards', async () => {
+test.describe('Real wallet - Portfolio - Staking rewards', async () => {
 	test.beforeEach(async ({ app, metamask }, testInfo) => {
 		// Extending tests timeout by 25 extra seconds due to beforeEach actions
 		testInfo.setTimeout(testInfo.timeout + 45_000);
@@ -147,13 +131,17 @@ test.describe.skip('Real wallet - Portfolio - Staking USDC rewards', async () =>
 		}).toPass();
 	});
 
-	test('It should claim rewards (until tx) @regression', async ({ app, metamask }) => {
+	test('It should claim LVUSDC rewards (until tx) @regression', async ({ app, metamask }) => {
 		test.setTimeout(veryLongTestTimeout);
 
-		//
-		await app.pause();
-		//
+		await app.portfolio.rewards.switchToBaseToClaimRewards();
+		await metamask.approveNewNetwork();
+		await metamask.approveSwitchNetwork();
 
-		//TO BE DONE
+		// Pause to avoid random fails
+		await app.page.waitForTimeout(2_000);
+
+		await app.portfolio.rewards.claimRewards();
+		await metamask.rejectTransaction();
 	});
 });


### PR DESCRIPTION
## Description

This PR enhances the Portfolio rewards page objects and updates the real wallet end-to-end tests for claiming $SUMR and Staking rewards across multiple networks (Sonic, Base, Arbitrum, Ethereum). It introduces support for approving the Staking Rewards Caller contract and stabilizes multi-chain wallet interactions.

### Changes

- **Rewards Page Objects (`srcEarnProtocol/pages/portfolio/rewards/`)**:
  - **`ClaimAndDelegate`**: Added `approveStakingRewardsCaller()` step method to interact with the new approval flow. Formatted trailing commas.
  - **`Rewards`**: Added helper step methods `switchToBaseToClaimRewards()` and `claimRewards()` to support staking rewards interactions. Sorted imports and formatted assertions.

- **Production Real Wallet Tests (`testsEarnProtocol/production/realWallet/sumrRewards.spec.ts`)**:
  - Re-enabled the main regression rewards claim test (`test.skip` -> `test`) with `veryLongTestTimeout`.
  - Added an initial Sonic claim step (expecting failure/rejection until further accrual).
  - Updated the Base network claim flow to handle new network approvals, network switching, and calling `approveStakingRewardsCaller()`.
  - Replaced generic timeout intervals with explicit `3_000`ms waits between network switches to prevent UI/wallet sync flakiness.

- **Staging Real Wallet Tests (`testsEarnProtocol/withRealWallet/portfolio/sumrRewards.spec.ts`)**:
  - Re-enabled the main SUMR rewards claim regression test and cleaned up excessive `app.pause()` debugging statements from the Base rewards flow.
  - Activated and implemented the previously skipped Staking Rewards test suite (`Real wallet - Portfolio - Staking rewards`):
    - Added comprehensive steps for claiming `LVUSDC` rewards utilizing `switchToBaseToClaimRewards()`, handling network/switch approvals, and invoking `claimRewards()`.
