### PR TITLE
Remove DAO ETH assertions in Mainnet tests

### DIFF
--- a/testsEarnProtocol/withRealWallet/mainnet/daoUsdcHR_PositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/mainnet/daoUsdcHR_PositionPage.spec.ts
@@ -1,11 +1,11 @@
-import { testWithSynpress } from '@synthetixio/synpress';
-import { test as withRealWalletBaseFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletBase';
-import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
-import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
-import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
-import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
-import { switchPosition } from 'testsEarnProtocol/z_sharedTestSteps/switch';
 import { expect } from '#earnProtocolFixtures';
+import { testWithSynpress } from '@synthetixio/synpress';
+import { logInWithWalletAddress } from 'srcEarnProtocol/utils/logIn';
+import { deposit } from 'testsEarnProtocol/z_sharedTestSteps/deposit';
+import { switchPosition } from 'testsEarnProtocol/z_sharedTestSteps/switch';
+import { withdraw } from 'testsEarnProtocol/z_sharedTestSteps/withdraw';
+import { expectDefaultTimeout, veryLongTestTimeout } from 'utils/config';
+import { test as withRealWalletBaseFixtures } from '../../../srcEarnProtocol/fixtures/withRealWalletBase';
 
 const test = testWithSynpress(withRealWalletBaseFixtures);
 
@@ -287,15 +287,16 @@ test.describe('With real wallet - DAO Mainnet USDC Higher Risk position page - S
 		});
 
 		await app.positionPage.sidebar.switch.targetPositionsShouldBe([
-			{
-				network: 'ethereum',
-				token: 'ETH',
-				riskLevel: 'Higher Risk',
-				riskManagementType: 'DAO Risk-Managed',
-				thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
-				liveAPY: '[0-9]{1,2}.[0-9]{2}',
-				apySpread: '[0-9]{1,2}.[0-9]{2}',
-			},
+			// SKIP - CAP set temporarily to 0
+			// {
+			// 	network: 'ethereum',
+			// 	token: 'ETH',
+			// 	riskLevel: 'Higher Risk',
+			// 	riskManagementType: 'DAO Risk-Managed',
+			// 	thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
+			// },
 			{
 				network: 'ethereum',
 				token: 'USDC',

--- a/testsEarnProtocol/withRealWallet/mainnet/ethHigherRiskPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/mainnet/ethHigherRiskPositionPage.spec.ts
@@ -315,15 +315,16 @@ test.describe('With real wallet - Mainnet ETH Higher Risk position page - Switch
 		});
 
 		await app.positionPage.sidebar.switch.targetPositionsShouldBe([
-			{
-				network: 'ethereum',
-				token: 'ETH',
-				riskLevel: 'Higher Risk',
-				riskManagementType: 'DAO Risk-Managed',
-				thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
-				liveAPY: '[0-9]{1,2}.[0-9]{2}',
-				apySpread: '[0-9]{1,2}.[0-9]{2}',
-			},
+			// SKIP - CAP set temporarily to 0
+			// {
+			// 	network: 'ethereum',
+			// 	token: 'ETH',
+			// 	riskLevel: 'Higher Risk',
+			// 	riskManagementType: 'DAO Risk-Managed',
+			// 	thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
+			// },
 			// SKIP - Wrong "30d APY" in staging
 			// {
 			// 	network: 'ethereum',

--- a/testsEarnProtocol/withRealWallet/mainnet/ethLowerRiskPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/mainnet/ethLowerRiskPositionPage.spec.ts
@@ -301,15 +301,16 @@ test.describe('With real wallet - Mainnet ETH Lower Risk position page - Switch'
 			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
 			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
 			// },
-			{
-				network: 'ethereum',
-				token: 'ETH',
-				riskLevel: 'Higher Risk',
-				riskManagementType: 'DAO Risk-Managed',
-				thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
-				liveAPY: '[0-9]{1,2}.[0-9]{2}',
-				apySpread: '[0-9]{1,2}.[0-9]{2}',
-			},
+			// SKIP - CAP set temporarily to 0
+			// {
+			// 	network: 'ethereum',
+			// 	token: 'ETH',
+			// 	riskLevel: 'Higher Risk',
+			// 	riskManagementType: 'DAO Risk-Managed',
+			// 	thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
+			// },
 			{
 				network: 'ethereum',
 				token: 'USDC',

--- a/testsEarnProtocol/withRealWallet/mainnet/usdcHigherRiskPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/mainnet/usdcHigherRiskPositionPage.spec.ts
@@ -299,15 +299,16 @@ test.describe('With real wallet - Mainnet USDC Higher Risk position page - Switc
 			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
 			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
 			// },
-			{
-				network: 'ethereum',
-				token: 'ETH',
-				riskLevel: 'Higher Risk',
-				riskManagementType: 'DAO Risk-Managed',
-				thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
-				liveAPY: '[0-9]{1,2}.[0-9]{2}',
-				apySpread: '[0-9]{1,2}.[0-9]{2}',
-			},
+			// SKIP - CAP set temporarily to 0
+			// {
+			// 	network: 'ethereum',
+			// 	token: 'ETH',
+			// 	riskLevel: 'Higher Risk',
+			// 	riskManagementType: 'DAO Risk-Managed',
+			// 	thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
+			// },
 			{
 				network: 'ethereum',
 				token: 'USDC',

--- a/testsEarnProtocol/withRealWallet/mainnet/usdcLowerRiskPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/mainnet/usdcLowerRiskPositionPage.spec.ts
@@ -299,15 +299,16 @@ test.describe('With real wallet - Mainnet USDC Lower Risk position page - Switch
 			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
 			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
 			// },
-			{
-				network: 'ethereum',
-				token: 'ETH',
-				riskLevel: 'Higher Risk',
-				riskManagementType: 'DAO Risk-Managed',
-				thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
-				liveAPY: '[0-9]{1,2}.[0-9]{2}',
-				apySpread: '[0-9]{1,2}.[0-9]{2}',
-			},
+			// SKIP - CAP set temporarily to 0
+			// {
+			// 	network: 'ethereum',
+			// 	token: 'ETH',
+			// 	riskLevel: 'Higher Risk',
+			// 	riskManagementType: 'DAO Risk-Managed',
+			// 	thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
+			// },
 			// SKIP - Wrong "30d APY" in staging
 			// {
 			// 	network: 'ethereum',

--- a/testsEarnProtocol/withRealWallet/mainnet/usdtPositionPage.spec.ts
+++ b/testsEarnProtocol/withRealWallet/mainnet/usdtPositionPage.spec.ts
@@ -286,15 +286,16 @@ test.describe('With real wallet - Mainnet USDT Position page - Switch', async ()
 		});
 
 		await app.positionPage.sidebar.switch.targetPositionsShouldBe([
-			{
-				network: 'ethereum',
-				token: 'ETH',
-				riskLevel: 'Higher Risk',
-				riskManagementType: 'DAO Risk-Managed',
-				thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
-				liveAPY: '[0-9]{1,2}.[0-9]{2}',
-				apySpread: '[0-9]{1,2}.[0-9]{2}',
-			},
+			// SKIP - CAP set temporarily to 0
+			// {
+			// 	network: 'ethereum',
+			// 	token: 'ETH',
+			// 	riskLevel: 'Higher Risk',
+			// 	riskManagementType: 'DAO Risk-Managed',
+			// 	thirtyDayAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	liveAPY: '[0-9]{1,2}.[0-9]{2}',
+			// 	apySpread: '[0-9]{1,2}.[0-9]{2}',
+			// },
 			// SKIP - Wrong "30d APY" in staging
 			// {
 			// 	network: 'ethereum',


### PR DESCRIPTION
# Remove DAO ETH assertions in Mainnet tests
Assertions to be re-enabled once deposits are allowed in DAO ETH vault 